### PR TITLE
Enforce Per-year Composites

### DIFF
--- a/src/scripts/spectral_recovery.py
+++ b/src/scripts/spectral_recovery.py
@@ -17,76 +17,111 @@ from spectral_recovery.io.raster import read_and_stack_tifs, metrics_to_tifs
 INDEX_CHOICE = [i.value for i in Index]
 METRIC_CHOICE = [str(m) for m in Metric]
 
-# TODO: simplify this function by grouping commands across multiple (3-4) smaller functions. 
+
+# TODO: simplify this function by grouping commands across multiple (3-4) smaller functions.
 @click.command()
 @click.argument("tif_dir", type=click.Path(exists=True, path_type=Path))
-@click.option("--years", type=click.DateTime(formats=["%Y"]), nargs=2, required=True, help="Start and end year of tifs in 'TIF_DIR'")
-@click.option("--per-band", is_flag=True, help="If tifs are stored per-band (e.g a tif for Blue band, containing years 2010-2022)")
-@click.option("--per-year", is_flag=True, help="If tifs are stored per-year (e.g a tif for 2010, containing bands Blue, NIR, and SWIR)")
-@click.option("-rest", "--rest-poly",type=click.Path(exists=True, path_type=Path), required=True, help="Path to restoration area polygon")
-@click.option("--rest-year", type=click.DateTime(formats=["%Y"]), nargs=1, required=False, help="Year of restoration event")
-@click.option("-ref","--ref-poly", type=click.Path(exists=True, path_type=Path), required=False, help="Path to reference polygon(s)")
-@click.option("--ref-years", type=click.DateTime(formats=["%Y"]), nargs=2, required=True, help="Start and end year from which to derive reference recovery target. If only using one year, set start and end year to same year.")
-@click.option("-i","--indices", type=click.Choice(
-    INDEX_CHOICE, 
-    case_sensitive=False,
-),
-multiple=True,
-required=False,
-help="The indices on which to compute recovery metrics.")
-@click.option("-m","--metrics", 
-type=click.Choice(
-    METRIC_CHOICE, 
-    case_sensitive=False,
-),
-multiple=True,
-required=True,
-help="The recovery metrics to compute.")
-@click.option("--mask", type=click.Path(exists=True, path_type=Path), required=False, help="A data mask.")
-@click.option("--out", type=click.Path(path_type=Path), required=True, help="Directory to write output rasters.")
+@click.argument(
+    "rest_poly",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.argument(
+    "rest_year",
+    type=click.DateTime(formats=["%Y"]),
+    nargs=1,
+)
+@click.option(
+    "-ref",
+    "--ref-poly",
+    type=click.Path(exists=True, path_type=Path),
+    required=False,
+    help="Path to reference polygon(s).",
+)
+@click.argument(
+    "ref_years",
+    type=click.DateTime(formats=["%Y"]),
+    nargs=2,
+)
+@click.option(
+    "-i",
+    "--indices",
+    type=click.Choice(
+        INDEX_CHOICE,
+        case_sensitive=False,
+    ),
+    multiple=True,
+    required=False,
+    help="The indices on which to compute recovery metrics.",
+)
+@click.option(
+    "-m",
+    "--metrics",
+    type=click.Choice(
+        METRIC_CHOICE,
+        case_sensitive=False,
+    ),
+    multiple=True,
+    required=True,
+    help="The recovery metrics to compute.",
+)
+@click.option(
+    "--mask",
+    type=click.Path(exists=True, path_type=Path),
+    required=False,
+    help="Path to a data mask for annual composites.",
+)
+@click.option(
+    "-o",
+    "--out",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Directory to write output rasters.",
+)
 def cli(
     tif_dir: List[str],
-    years,
-    per_band,
-    per_year,
-    rest_poly: str,
-    rest_year: int,
-    ref_poly,
+    rest_poly: Path,
+    rest_year: str,
+    ref_poly: Path,
     ref_years: str,
     metrics: List[str],
-    out,
+    out: Path,
     indices: List[str] = None,
     mask: xr.DataArray = None,
 ) -> None:
-    """ CLI-tool for computing recovery metrics over a desired restoration area. """
-    start_year, end_year = years
+    """Compute recovery metrics.
 
+    This script will compute recovery METRICS over the area of REST_POLY
+    using spectral data from annual composites in TIF_DIR. Recovery targets
+    will be derived from REF_YEARS and restoration event occurs in REST_YEAR.
+
+    \b
+    TIF_DIR        Path to a directory containing annual composites.
+    REST_POLY      Path to the restoration area polygon.
+    REST_YEAR      Year of the restoration event.
+    REF_YEARS      Start and end years over which to derive a recovery target.
+    
+    """
     # TODO: move user input prep/validation into own function?
-    start_year = pd.to_datetime(start_year)
-    end_year = pd.to_datetime(end_year)
     rest_year = pd.to_datetime(rest_year)
     ref_years = [pd.to_datetime(ref_years[0]), pd.to_datetime(ref_years[1])]
     try:
         valid_metrics = [Metric[name] for name in metrics]
     except KeyError as e:
         raise e from None
-    
+
     try:
         valid_indices = [Index[name.lower()] for name in indices]
     except KeyError as e:
         raise e from None
-        
-    p = Path(tif_dir).glob('*.tif')
+
+    p = Path(tif_dir).glob("*.tif")
     tifs = [x for x in p if x.is_file()]
 
     with LocalCluster() as cluster, Client(cluster) as client:
-        timeseries = read_and_stack_tifs(path_to_tifs=tifs,
-                                        per_band=per_band,
-                                        per_year=per_year,
-                                        path_to_mask=mask,
-                                        start_year=start_year,
-                                        end_year=end_year
-                                        )
+        timeseries = read_and_stack_tifs(
+            path_to_tifs=tifs,
+            path_to_mask=mask,
+        )
 
         if not timeseries.satts.valid:
             raise ValueError("Stack is not a valid yearly composite stack.")
@@ -105,7 +140,7 @@ def cli(
             )
         else:
             ref_sys = ref_years
-        
+
         rest_poly_gdf = gpd.read_file(rest_poly)
         metrics_array = RestorationArea(
             restoration_polygon=rest_poly_gdf,

--- a/src/spectral_recovery/io/raster.py
+++ b/src/spectral_recovery/io/raster.py
@@ -7,6 +7,7 @@ import xarray as xr
 from pathlib import Path
 from typing import List
 from rasterio._err import CPLE_AppDefinedError
+from pandas.core.tools.datetimes import DateParseError
 
 from spectral_recovery.enums import BandCommon, Index
 
@@ -15,11 +16,7 @@ REQ_DIMS = ["band", "time", "y", "x"]
 
 def read_and_stack_tifs(
     path_to_tifs: List[str],
-    per_year: bool = False,
-    per_band: bool = False,
     path_to_mask: str = None,
-    start_year: str = None,
-    end_year: str = None,
 ):
     """ Reads and stacks a list of tifs into a 4D DataArray.
 
@@ -33,58 +30,29 @@ def read_and_stack_tifs(
     per_year : bool, optional 
     per_band : bool, optional
     path_to_mask : str, optional
-    start_year : str, optional
-    end_year : str, optional
 
     Returns
     -------
     stacked_data : xr.DataArray
 
     """
-    if not per_year and not per_band:
-        raise ValueError("Expected either per_year or per_band to be set.") from None
-    if per_year and per_band:
-        raise ValueError("Only one of per_year or per_band can be True.") from None
-
     image_dict = {}
     for file in path_to_tifs:
         with rioxarray.open_rasterio(Path(file), chunks="auto") as data:
             image_dict[Path(file).stem] = data
+    try:
+        time_keys = []
+        for filename in image_dict.keys():
+            time_keys.append(pd.to_datetime(filename))
+    except DateParseError:
+        # TODO: add more information here for users. Either link to additional docs or make error message more descriptive.
+        raise ValueError(
+            f"TIF filenames must be in format 'YYYY' but recived: '{filename}'"
+        ) from None
+    stacked_data = _stack_bands(image_dict.values(), time_keys, dim_name="time")
+    band_names = _to_band_or_index(stacked_data.attrs["long_name"])
+    stacked_data = stacked_data.assign_coords(band=list(band_names.values()))
 
-    if per_year:
-        try:
-            time_keys = [pd.to_datetime(filename) for filename in image_dict.keys()]
-        except ValueError:
-            # TODO: add more information here for users. Either link to additional docs or make error message more descriptive.
-            raise ValueError(
-                "Cannot stack tifs because per_year=True but filenames of TIFs are not"
-                " in 'YYYY.tif' format."
-            ) from None
-        stacked_data = _stack_bands(image_dict.values(), time_keys, dim_name="time")
-        band_names = _to_band_or_index(stacked_data.attrs["long_name"])
-        stacked_data = stacked_data.assign_coords(band=list(band_names.values()))
-
-    if per_band:
-        if not start_year and not end_year:
-            raise ValueError("Cannot stack tifs because per_band=True but start_year and end_year are not provided. Start and end years of the timeseries must be defined because it cannot be assumed from the TIFs.")
-        
-        try:
-            band_keys = _to_band_or_index(image_dict.keys())
-            image_dict = { band_keys[key] : value for key, value in image_dict.items() }
-        except ValueError:
-            # TODO: add accepted values to error message and direct user to documentation 
-                raise ValueError(
-                    "Cannot stack bands because per_band=True but filenames of TIFs"
-                    " are not recognized common band name or index acronym."
-                ) from None
-        
-        for key, data in image_dict.items():
-            image_dict[key] = data.rename({"band": "time"})
-            stacked_data = _stack_bands(
-            image_dict.values(), image_dict.keys(), dim_name="band")
-
-        stacked_data = stacked_data.assign_coords(
-        time=(pd.date_range(start=start_year, end=end_year, freq=DATETIME_FREQ)))
     # TODO: catch missing dimension error here
     stacked_data = stacked_data.transpose(*REQ_DIMS)
     stacked_data = stacked_data.sortby("time")
@@ -143,11 +111,10 @@ def metrics_to_tifs(
             try:
                 filename = f"{out_dir}/{str(metric)}.tif"
                 xa_dataset.rio.to_raster(raster_path=filename)
+            # TODO: don't except on an error hidden from API users...
             except CPLE_AppDefinedError as exc:
                 raise PermissionError(
-                    f"Could not write output to {filename} because a TIF already"
-                    " exists and could not be overwritten, likely because"
-                    " it's open elsewhere. Is the existing TIF open in an"
+                    f"Permission denied to overwrite {filename}. Is the existing TIF open in an"
                     " application (e.g QGIS)? If so, try closing it before your"
                     " next run to avoid this error."
                 ) from None


### PR DESCRIPTION
Currently, `scripts.spectral_recovery` and `io.read_and_stack_tifs` allow users to pass a list of TIFs that are either per-year (e.g 2010.tif, 2011.tif, etc. containing multiple bands) or per-band (red.tif, blue.tif, etc. containing multiple bands representing years). This is a relic from initial IO design of the tool. 

This PR introduces a simpler IO procedure/CLI entry-point that only accepts per-year TIFs. This change reduces the number of options required in the CLI and avoids unnecessary complexity in IO logic. Users are now required to pass a path to a directory of tifs, all of which are named 'YYYY' where YYYY is composite year the tif represents. Each tif can contain multiple bands, but each band needs to be labelled (e.g blue, nir)

If users determine that a more flexible IO procedure is ideal, then future version of the project can address this; potentially adding back in this removed logic. For now however, we should focus on simpler, restrictive use-cases to make the API/CLI as simple as possible.