### PR TITLE
Update Recovery Target  methods

### DIFF
--- a/src/spectral_recovery/recovery_target.py
+++ b/src/spectral_recovery/recovery_target.py
@@ -12,15 +12,15 @@ def median_target(
     """
     Compute the median recovery target.
 
-    Sequentially computes the median over time and spatial dimensions. If there
-    is a "poly_id" dimension, the median is automatically computed along that
-    dimension after the time and space dimensions.
-
+    Sequentially computes the median over time and, optionally, the spatial
+    dimensions (x and y). If there is a "poly_id" dimension, then the median is
+    automatically computed along that dimension after the time and space dimensions.
+    
     Parameters
     ----------
     stack : xr.DataArray
         DataArray of images to derive historic average from. Must have at least
-        4 labelled dimensions: "time", "band", "y" and "x". Optional 5th dimension
+        4 labelled dimensions: "time", "band", "y" and "x" and optionally,
         "poly_id".
     reference_date : Union[datetime, Tuple[datetime]]
         The date or date range to compute the median over.

--- a/src/spectral_recovery/recovery_target.py
+++ b/src/spectral_recovery/recovery_target.py
@@ -9,13 +9,13 @@ from datetime import datetime
 def historic_average(
     stack: xr.DataArray, reference_date: Union[datetime, Tuple[datetime]]
 ) -> xr.DataArray:
-    # TODO: should this just return a simple list?
-    # TODO: should this take _just_ pd datetimeIndex?
     """
     Compute the average within a stack over all dimensions except time. 
 
-    Will average over time, then y/x, then poly_id (if present). Resulting
-    DataArray will have one target value per band.
+    Sequentially computes the median on the time dimension, the y and x dimension.
+    If there is a "poly_id" dimension, the median is computed along that dimension
+    after the x dimension. The final result is a median value for each band in the
+    band dimension.
 
     Parameters
     ----------
@@ -28,6 +28,7 @@ def historic_average(
     -------
     historic_average : xr.DataArray
         A 1D DataArray of historic average.
+
     """
     if isinstance(reference_date, list):
         ranged_stack = stack.sel(time=slice(*reference_date))

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -297,7 +297,7 @@ class RestorationArea:
         recovery_target = self.reference_system.recovery_target()
         y2r = m.Y2R(
             image_stack=post_restoration,
-            recovery_target=recovery_target["recovery_target"],
+            recovery_target=recovery_target,
             rest_start=str(self.restoration_start.year),
             percent=percent_of_target,
         )
@@ -337,7 +337,7 @@ class RestorationArea:
         r80p = m.R80P(
             image_stack=self.stack,
             rest_start=str(self.restoration_start.year),
-            recovery_target=recovery_target["recovery_target"],
+            recovery_target=recovery_target,
             timestep=timestep,
             percent=percent_of_target,
         )

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -76,11 +76,11 @@ class ReferenceSystem:
         """Get the recovery target for a reference system"""
         if self.hist_ref_sys:
             recovery_target = self.recovery_target_method(
-                self.reference_stack, self.reference_range, space=False
+                reference_stack=self.reference_stack, reference_range=self.reference_range, space=False
             )
         else:
             recovery_target = self.recovery_target_method(
-                self.reference_stack, self.reference_range, space=True
+                reference_stack=self.reference_stack, reference_range=self.reference_range, space=True
             )
         return {"recovery_target": recovery_target}
 

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -76,11 +76,11 @@ class ReferenceSystem:
         """Get the recovery target for a reference system"""
         if self.hist_ref_sys:
             recovery_target = self.recovery_target_method(
-                reference_stack=self.reference_stack, reference_range=self.reference_range, space=False, hist_ref_sys=self.hist_ref_sys
+                reference_stack=self.reference_stack, reference_range=self.reference_range, space=False,
             )
         else:
             recovery_target = self.recovery_target_method(
-                reference_stack=self.reference_stack, reference_range=self.reference_range, space=True, hist_ref_sys=self.hist_ref_sys
+                reference_stack=self.reference_stack, reference_range=self.reference_range, space=True,
             )
         if not self.hist_ref_sys:
             if recovery_target.dims == ("band","y", "x"):

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -2,6 +2,7 @@ import xarray as xr
 import geopandas as gpd
 import pandas as pd
 from pandas import Index
+import seaborn as sns
 
 from typing import Callable, Optional, Union, List
 from datetime import datetime
@@ -335,3 +336,17 @@ class RestorationArea:
         )
         r80p = r80p.expand_dims(dim={"metric": [Metric.R80P]})
         return r80p
+    
+    def plot_spectral_timeseries(self):
+        """Plot a spectral timeseries of the RestorationArea"""
+        stats = self.stack.satts.stats()
+        stats = stats.sel(stats=["median", "min", "max", "mean", "std"])
+        stats = stats.to_dataframe("value").reset_index()
+        stats["Time"] = stats["time"].dt.year
+        stats = stats.rename(columns={"stats": "Statistic"})
+        stats = stats.melt(id_vars=["time", "Statistic"], var_name="Band", value_name="Value")
+        g = sns.FacetGrid(stats, col="Band", hue="Statistic", sharey=False, sharex=False)
+        g.map(sns.lineplot, "Time", "Value")
+        g.add_legend()
+        g.show()
+

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -247,16 +247,18 @@ class RestorationArea:
                 reference_range=self.reference_years,
                 reference_stack=composite_stack,
                 recovery_target_method=None,
+                historic_reference_system=True,
             )
         else:
             # Build the reference polygon from the reference polygon
             # Use the unclipped composite_stack instead of self.stack because
-            # self.stack is clipped to restoration_polygons.
+            # self.stack is clipped to restoration_polygons at this point.
             self.reference_system = ReferenceSystem(
                 reference_polygons=reference_polygon,
                 reference_range=self.reference_years,
                 reference_stack=composite_stack,
                 recovery_target_method=None,
+                historic_reference_system=False,
             )
 
         self.end_year = pd.to_datetime(self.stack["time"].max().data)

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -82,7 +82,7 @@ class ReferenceSystem:
             recovery_target = self.recovery_target_method(
                 reference_stack=self.reference_stack, reference_range=self.reference_range, space=True
             )
-        return {"recovery_target": recovery_target}
+        return recovery_target
 
     def _within(self, stack: xr.DataArray) -> bool:
         """Check if within a DataArray

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -46,7 +46,7 @@ class ReferenceSystem:
         reference_stack: xr.DataArray,
         reference_range: Union[datetime, List[datetime]],
         reference_polygons: gpd.GeoDataFrame,
-        historic_reference_system: bool = False,
+        historic_reference_system: bool,
         recovery_target_method: Optional[Callable] = None,
     ) -> None:
         # TODO: convert date inputs into standard form (pd.dt?)
@@ -76,12 +76,16 @@ class ReferenceSystem:
         """Get the recovery target for a reference system"""
         if self.hist_ref_sys:
             recovery_target = self.recovery_target_method(
-                reference_stack=self.reference_stack, reference_range=self.reference_range, space=False
+                reference_stack=self.reference_stack, reference_range=self.reference_range, space=False, hist_ref_sys=self.hist_ref_sys
             )
         else:
             recovery_target = self.recovery_target_method(
-                reference_stack=self.reference_stack, reference_range=self.reference_range, space=True
+                reference_stack=self.reference_stack, reference_range=self.reference_range, space=True, hist_ref_sys=self.hist_ref_sys
             )
+        if recovery_target.dims == ("band","y", "x"):
+            raise ValueError(
+                "Recovery target using reference polygons must be computed along the space dimensions."
+            ) from None
         return recovery_target
 
     def _within(self, stack: xr.DataArray) -> bool:

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -82,10 +82,11 @@ class ReferenceSystem:
             recovery_target = self.recovery_target_method(
                 reference_stack=self.reference_stack, reference_range=self.reference_range, space=True, hist_ref_sys=self.hist_ref_sys
             )
-        if recovery_target.dims == ("band","y", "x"):
-            raise ValueError(
-                "Recovery target using reference polygons must be computed along the space dimensions."
-            ) from None
+        if not self.hist_ref_sys:
+            if recovery_target.dims == ("band","y", "x"):
+                raise ValueError(
+                    "Recovery target using reference polygons must be computed along the space dimensions."
+                ) from None
         return recovery_target
 
     def _within(self, stack: xr.DataArray) -> bool:

--- a/src/tests/test_indices.py
+++ b/src/tests/test_indices.py
@@ -102,7 +102,7 @@ class TestCompatiableWithDecorator:
         def to_be_decorated(stack):
             return "hello"
 
-        test_stack = xr.DataArray([0], dims=["time"], attrs={"platform": Platform.landsat_oli})
+        test_stack = xr.DataArray([0], dims=["time"], attrs={"platform": [Platform.landsat_oli]})
         assert to_be_decorated(test_stack) == "hello"
     
     def test_platform_diff_than_decorator_throws_value_err(self):
@@ -110,6 +110,6 @@ class TestCompatiableWithDecorator:
         def to_be_decorated(stack):
             return "hello"
 
-        test_stack = xr.DataArray([0], dims=["time"], attrs={"platform": Platform.sentinel_2})
+        test_stack = xr.DataArray([0], dims=["time"], attrs={"platform": [Platform.sentinel_2]})
         with pytest.raises(ValueError):
             to_be_decorated(test_stack)

--- a/src/tests/test_recovery_target.py
+++ b/src/tests/test_recovery_target.py
@@ -3,7 +3,7 @@ import xarray as xr
 
 
 from xarray.testing import assert_equal
-from spectral_recovery.recovery_target import historic_average
+from spectral_recovery.recovery_target import median_target
 
 
 class TestHistoricAverage:
@@ -33,7 +33,7 @@ class TestHistoricAverage:
                 "band": [0, 1],
             },
         )
-        out_stack = historic_average(test_stack, [0, 1])
+        out_stack = median_target(test_stack, [0, 1])
         assert_equal(out_stack, expected_stack)
 
     def test_odd_time_dim_returns_median(self):
@@ -66,7 +66,7 @@ class TestHistoricAverage:
                 "band": [0, 1],
             },
         )
-        out_stack = historic_average(test_stack, [0, 2])
+        out_stack = median_target(test_stack, [0, 2])
         assert_equal(out_stack, expected_stack)
 
     def test_nan_timeseries_is_nan(self):
@@ -95,7 +95,7 @@ class TestHistoricAverage:
                 "band": [0, 1],
             },
         )
-        out_stack = historic_average(test_stack, [0, 1])
+        out_stack = median_target(test_stack, [0, 1])
         assert_equal(out_stack, expected_stack)
 
     def test_nan_in_timeseries_ignored(self):
@@ -124,7 +124,7 @@ class TestHistoricAverage:
                 "band": [0, 1],
             },
         )
-        out_stack = historic_average(test_stack, [0, 1])
+        out_stack = median_target(test_stack, [0, 1])
         assert_equal(out_stack, expected_stack)
 
     def test_multi_poly_averages_individual_polygon(self):
@@ -161,5 +161,45 @@ class TestHistoricAverage:
                 "band": [0],
             },
         )
-        out_stack = historic_average(test_stack, [0, 1])
+        out_stack = median_target(test_stack, [0, 1])
+        assert_equal(out_stack, expected_stack)
+
+    def test_space_false_returns_correct_dimensions(self):
+        test_data = np.arange(8).reshape(1, 2, 2, 2)
+        test_stack = xr.DataArray(
+            test_data,
+            dims=["band", "time", "y", "x"],
+            coords={
+                "time": [0, 1],
+            },
+        )
+        out_stack = median_target(test_stack, [0, 1], space=False)
+        assert out_stack.dims == ("band", "y", "x")
+        assert out_stack.shape == (1, 2, 2)
+    
+    def test_space_false_returns_per_pixel_median(self):
+        test_data = [ 
+                [ 
+                    [[1.0, 2.0], [3.0, 4.0]],  
+                    [[5.0, 6.0], [8.0, 9.0]],  
+                ],
+            ]
+        test_stack = xr.DataArray(
+            test_data,
+            dims=["band", "time", "y", "x"],
+            coords={
+                "time": [0, 1],
+            },
+        )
+        
+        expected_data = [[[3.0, 4.0], [5.5, 6.5]]]
+        expected_stack = xr.DataArray(
+            expected_data,
+            dims=["band", "y", "x"],
+            coords={
+                "band": [0],
+            },
+        )
+
+        out_stack = median_target(test_stack, [0, 1], space=False)
         assert_equal(out_stack, expected_stack)

--- a/src/tests/test_recovery_target.py
+++ b/src/tests/test_recovery_target.py
@@ -129,20 +129,20 @@ class TestHistoricAverage:
 
     def test_multi_poly_averages_individual_polygon(self):
         test_data = [
-            [
-                [
-                    [[1.0, 1.0], [np.nan, np.nan]],  # y 1, x1  # y 2, x1  # band 1
+            [ # Polygon 1
+                [ # Time 1
+                    [[1.0, 2.0], [3.0, 4.0]],  # y1, x1  # y2, x1  # band 1
                 ],
-                [
-                    [[3.0, 6.0], [np.nan, np.nan]],  # y 1  # band 1
+                [ # Time 2
+                    [[5.0, 6.0], [8.0, 9.0]],  # y1, x2   # band 1
                 ],
             ],
-            [
+            [ # Polygon 2
                 [
-                    [[np.nan, np.nan], [np.nan, 2.0]],  # y 1, x1  # y 2, x1  # band 1
+                    [[1.0, 2.0], [3.0, 4.0]],  # y 1, x1  # y 2, x1  # band 1
                 ],
                 [
-                    [[np.nan, np.nan], [np.nan, 6.0]],  # y 1  # band 1
+                    [[5.0, 6.0], [8.0, 9.0]],  # y 1  # band 1
                 ],
             ],
         ]
@@ -153,7 +153,7 @@ class TestHistoricAverage:
                 "time": [0, 1],
             },
         )
-        expected_data = [3.375]
+        expected_data = [4.75]
         expected_stack = xr.DataArray(
             expected_data,
             dims=["band"],

--- a/src/tests/test_restoration.py
+++ b/src/tests/test_restoration.py
@@ -741,9 +741,38 @@ class TestReferenceSystemInit:
                 reference_range=reference_date,
                 recovery_target_method=None,
             )
+    
+    def test_historic_reference_system_bool_default_is_False(self, image_stack):
+        reference_polys = gpd.read_file(
+            "src/tests/test_data/polygon_multi_inbound_epsg3005.gpkg"
+        )
+        reference_date = pd.to_datetime("2008")
+
+        rs = ReferenceSystem(
+            reference_polygons=reference_polys,
+            reference_stack=image_stack,
+            reference_range=reference_date,
+            recovery_target_method=None,
+        )
+        assert rs.hist_ref_sys == True
+    
+    def test_historic_reference_system_bool_is_set_True(self, image_stack):
+        reference_polys = gpd.read_file(
+            "src/tests/test_data/polygon_multi_inbound_epsg3005.gpkg"
+        )
+        reference_date = pd.to_datetime("2008")
+
+        rs = ReferenceSystem(
+            reference_polygons=reference_polys,
+            reference_stack=image_stack,
+            reference_range=reference_date,
+            recovery_target_method=None,
+            historic_reference_system=True,
+        )
+        assert rs.hist_ref_sys == True
 
 
-class TestReferenceSystemrecovery_target:
+class TestReferenceSystemRecoveryTarget:
     class SimpleReferenceSystem(ReferenceSystem):
         """Sub-class ReferenceSystem and overwrite __init__ to isolate `recovery_target` method."""
 

--- a/src/tests/test_restoration.py
+++ b/src/tests/test_restoration.py
@@ -449,7 +449,7 @@ class TestRestorationAreaMetrics:
                 composite_stack=stack,
             )
 
-            mock_target_return = {"recovery_target": self.baseline_array}
+            mock_target_return = self.baseline_array
             resto_area.reference_system.recovery_target = MagicMock(
                 return_value=mock_target_return
             )
@@ -798,3 +798,5 @@ class TestReferenceSystemRecoveryTarget:
         rs.recovery_target()
         rs.recovery_target_method.assert_called_once()
         rs.recovery_target_method.assert_called_with(reference_stack=0, reference_range=0, space=False)
+    
+    # TODO: test the return value is correct


### PR DESCRIPTION
 This PR introduces three major updates to the `spectral_recovery.recovery_target.historic_average` method:

1. Multi-axis reduction (i.e passing a list of axes to `axis=`) is changed to sequential calls. First the reduction is called over the time dimension, then reduction is called along both the x and y dimension (i.e array is flattened along x and y, then reduced). This change is introduced because the method used before, `axis=[time, y, x]`, produced incorrect results.
2. Mean replaces with median.
3. `space` boolean parameter is introduced to allow parameterization between per-pixel and per-polygon recovery targets because historical reference systems should use per-pixel approach while reference should use per-polygon. Further, `historical_reference_system` is introduced to `spectral_recovery.restoration.ReferenceSystem` to allow for appropriate calls to per-pixel or per-polygon depending on the type of reference system.

Tests were changed to reflect desired behavior from changes.