### PR TITLE
Add optional parameter for band name mapping

### DIFF
--- a/src/tests/test_io.py
+++ b/src/tests/test_io.py
@@ -206,7 +206,7 @@ class TestReadAndStackTifs:
 
         stacked_tifs = read_and_stack_tifs(
             path_to_tifs=filenames,
-            band_names={1: "blue", 2: "red", 3: "nir"}, 
+            band_names={0: "blue", 1: "red", 2: "nir"}, 
             platform=[Platform.landsat_oli],
         )
         assert np.all(stacked_tifs["band"].data == expected_bands)

--- a/src/tests/test_io.py
+++ b/src/tests/test_io.py
@@ -86,7 +86,7 @@ class TestReadAndStackTifs:
         mocked_rasterio_open.return_value = rasterio_return
         stacked_tifs = read_and_stack_tifs(
             path_to_tifs=tif_paths,
-            platform=Platform.landsat_oli,
+            platform=[Platform.landsat_oli],
             )
 
         assert stacked_tifs.sizes["time"] == len(tif_paths)
@@ -145,42 +145,93 @@ class TestReadAndStackTifs:
         ):
             read_and_stack_tifs(
                 path_to_tifs=filenames,
-                platform=Platform.landsat_oli
+                platform=[Platform.landsat_oli]
             )
 
-    @pytest.mark.parametrize(
-        ("expected_years", "filenames", "expected_bands", "rasterio_return"),
-        [
-            (
-                [np.datetime64("2019"), np.datetime64("2020"), np.datetime64("2021")],
-                [f"path/to/2019.tif", f"path/to/2020.tif", f"path/to/2021.tif"],
-                [BandCommon.blue, BandCommon.red, BandCommon.nir],
-                xr.DataArray(
-                    [[[[0]]], [[[0]]], [[[0]]]],
-                    dims=["band", "time", "y", "x"],
-                    attrs={"long_name": ["blue", "red", "nir"]},
-                ),
-            ),
-        ],
-    )
     @patch(
         "rioxarray.open_rasterio",
     )
-    def test_correct_coordinate_values_from_good_inputs(
-        self,
-        mocked_rasterio_open,
-        expected_years,
-        filenames,
-        expected_bands,
-        rasterio_return,
-    ):
+    def test_correct_coords_from_tifs_with_long_name(self, mocked_rasterio_open):
+        expected_years = [np.datetime64("2019"), np.datetime64("2020"), np.datetime64("2021")]
+        filenames = [f"path/to/2019.tif", f"path/to/2020.tif", f"path/to/2021.tif"]
+        expected_bands = [BandCommon.blue, BandCommon.red, BandCommon.nir]
+        rasterio_return =  xr.DataArray(
+                    [[[[0]]], [[[0]]], [[[0]]]],
+                    dims=["band", "time", "y", "x"],
+                    attrs={"long_name": ["blue", "red", "nir"]}          
+                    )
         mocked_rasterio_open.return_value = rasterio_return
+
         stacked_tifs = read_and_stack_tifs(
             path_to_tifs=filenames,
-            platform=Platform.landsat_oli
+            platform=[Platform.landsat_oli]
         )
         assert np.all(stacked_tifs["band"].data == expected_bands)
         assert np.all(stacked_tifs["time"].data == expected_years)
+    
+    @patch(
+        "rioxarray.open_rasterio",
+    )
+    def test_correct_coords_from_tifs_w_band_dict(self, mocked_rasterio_open):
+        expected_years = [np.datetime64("2019"), np.datetime64("2020"), np.datetime64("2021")]
+        filenames = [f"path/to/2019.tif", f"path/to/2020.tif", f"path/to/2021.tif"]
+        expected_bands = [BandCommon.blue, BandCommon.red, BandCommon.nir]
+        rasterio_return =  xr.DataArray(
+                    [[[[0]]], [[[0]]], [[[0]]]],
+                    dims=["band", "time", "y", "x"],     
+                    )
+        mocked_rasterio_open.return_value = rasterio_return
+
+        stacked_tifs = read_and_stack_tifs(
+            path_to_tifs=filenames,
+            band_names={1: "blue", 2: "red", 3: "nir"},
+            platform=[Platform.landsat_oli],
+        )
+        assert np.all(stacked_tifs["band"].data == expected_bands)
+        assert np.all(stacked_tifs["time"].data == expected_years)
+    
+    @patch(
+        "rioxarray.open_rasterio",
+    )
+    def test_band_dict_supersedes_band_desc(self, mocked_rasterio_open):
+        expected_years = [np.datetime64("2019"), np.datetime64("2020"), np.datetime64("2021")]
+        filenames = [f"path/to/2019.tif", f"path/to/2020.tif", f"path/to/2021.tif"]
+        expected_bands = [BandCommon.blue, BandCommon.red, BandCommon.nir]
+        rasterio_return =  xr.DataArray(
+                    [[[[0]]], [[[0]]], [[[0]]]],
+                    dims=["band", "time", "y", "x"],
+                    attrs={"long_name": ["swir", "green", "red"]}   
+                    )
+        mocked_rasterio_open.return_value = rasterio_return
+
+        stacked_tifs = read_and_stack_tifs(
+            path_to_tifs=filenames,
+            band_names={1: "blue", 2: "red", 3: "nir"}, 
+            platform=[Platform.landsat_oli],
+        )
+        assert np.all(stacked_tifs["band"].data == expected_bands)
+        assert np.all(stacked_tifs["time"].data == expected_years)
+    
+
+    @patch(
+        "rioxarray.open_rasterio",
+    )
+    def test_no_band_desc_or_band_names_throws_value_err(self, mocked_rasterio_open):
+        filenames = [f"path/to/2019.tif", f"path/to/2020.tif", f"path/to/2021.tif"]
+        rasterio_return =  xr.DataArray(
+                    [[[[0]]], [[[0]]], [[[0]]]],
+                    dims=["band", "time", "y", "x"],
+                    )
+        mocked_rasterio_open.return_value = rasterio_return
+
+        with pytest.raises(
+            ValueError,
+        ):
+            _ = read_and_stack_tifs(
+                path_to_tifs=filenames, 
+                platform=[Platform.landsat_oli],
+            )
+    
 
     @pytest.mark.parametrize(
         ("sorted_years", "filenames", "rasterio_return"),


### PR DESCRIPTION
This PR introduces a new parameter to `io.raster.read_and_stack_tifs` named `band_names`. `band_names` is expected to be a dictionary, mapping band coordinates/numbers to band names. The mapping is used to change the coordinates that rasterio assigns to the Xarray object when a raster file without band descriptions is read. Previously, the `read_and_stack_tifs` required band descriptions for each band in a TIFs, otherwise an error would be thrown.

This PR was started after noticing that on Planetary Computer the tool was unable to read band descriptions added into the TIF xml files. Generally, this feature is beneficial to the tool for two related reasons 1) Forcing users to have band descriptions in all of their TIFs could be cumbersome especially for those with long timeseries data 2) If band descriptions are not present in TIFs, there is no guarantee that Band 1 = Blue, even if we know the platform that the images are derived from (see #21).

If a mapping is provided to `band_names`, the mapping will supersede any band descriptions present in the TIFs. When a dictionary is provided, it cannot contain any band numbers that are not in from the TIFs (e.g if there are 2 bands, the dictionary cannot contain a mapping for bands 1,2, and 3). Finally, the mapping must be complete, so all bands in the TIF must be given a mapping in the dictionary passed to `band_names`.

Below is an example of usage of the `band_names` parameter:

```
# map band 1 -> nir, Band 2 -> swir2
sr.read_and_stack_tifs("test_data/", [Platform.landsat_tm], band_names={1: "nir", 2: "swir2"})
```




