### PR TITLE
Update Visualizations

### DIFF
--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -401,7 +401,7 @@ class RestorationArea:
         )
         for ax in g.axes.flat:
             ax.set_xlabel("Year")
-        g.axes[0,0].set_ylabel("Index Value")
+        g.axes[0,0].set_ylabel("Band/Index Value")
 
         # Plot spectral trajectory windows: reference, disturbance, recovery
         g.map(
@@ -488,12 +488,12 @@ class RestorationArea:
         if self.reference_system.hist_ref_sys:
             custom_handles.insert(2, (recovery_target_line, recovery_target_patch),)
             custom_handles.insert(3, (reference_years, reference_years_patch))
-            labels.insert(2, "historic recovery target (per-pixel)")
+            labels.insert(2, "historic recovery target (mean)")
             labels.insert(3, "reference year(s)")
            
         else:
             custom_handles.insert(2, recovery_target_line,)
-            labels.insert(2, "reference recovery target (per-polygon)")
+            labels.insert(2, "reference recovery target")
 
         plt.figlegend(
             labels=labels,


### PR DESCRIPTION
This PR introduces some updates to the spectral trajectory visualization feature. 

- Renamed from `plot_spectral_timeseries` to `plot_spectral_trajectory`
- Updated y-axis label, x-axis tick labels, and title for clarity.
- Dynamically alter plot content if reference system is historic or not. If historic, plots reference year window, per-pixel recovery target line, and unique legend label. If not historic, do not plot reference year window, plot per-polygon target line, and unique legend label.

![test_hist](https://github.com/PEOPLE-ER/Spectral-Recovery/assets/57023024/45f81182-d178-466c-8378-92e325de853a)
![test_ref](https://github.com/PEOPLE-ER/Spectral-Recovery/assets/57023024/7382355e-aeaf-4134-8ecd-b29286715c0b)
