### PR TITLE
Add red edge and coastal

### DIFF
--- a/src/spectral_recovery/enums.py
+++ b/src/spectral_recovery/enums.py
@@ -8,6 +8,8 @@ class BandCommon(Enum):
     nir = "NIR"
     swir1 = "SWIR1"
     swir2 = "SWIR2"
+    coastal_aerosol = "COASTAL_AEROSOL"
+    red_edge = "RED_EDGE"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
Adds "red edge" and "coastal aerosol" band names to BandCommon enum. 

These new bands are not used in the current set of implemented indices but having them in the enum will allow for users to provide images with those bands present without recieving errors. Will not effect indices computation, because only selected indices are used in computation.

Provides partial fix for #23.