### PR TITLE
ENH: Allow None recovery_target

### DIFF
--- a/src/spectral_recovery/metrics.py
+++ b/src/spectral_recovery/metrics.py
@@ -28,7 +28,7 @@ def compute_metrics(
     timeseries_data: xr.DataArray,
     restoration_polygons: gpd.GeoDataFrame,
     metrics: List[str],
-    recovery_target: xr.DataArray,
+    recovery_target: xr.DataArray = None,
     timestep: int = 5,
     percent_of_target: int = 80,
 ):
@@ -37,6 +37,12 @@ def compute_metrics(
         composite_stack=timeseries_data,
         recovery_target=recovery_target,
     )
+
+    if recovery_target is None:
+        for tmetric in ["Y2R", "R80P"]:
+            if tmetric in metrics:
+                raise ValueError(f"{tmetric} requires a recovery target but recovery_target is None")
+            
     m_results = []
     for m in metrics:
         try:

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -221,21 +221,22 @@ class RestorationArea:
 
     @recovery_target.setter
     def recovery_target(self, rt: xr.DataArray) -> xr.DataArray:
-        if set(rt.dims) != {"band", "y", "x"} and set(rt.dims) != {"band"}:
-            raise ValueError(
-                "recovery_target must contain the dimension 'band' and optionally the dimensions 'y', and 'x'"
-            )
-        if rt.sizes["band"] != self.restoration_image_stack.sizes["band"]:
-            raise ValueError(
-                f"recovery_target must contain the same number of bands as composite_stack ({rt.sizes['band']} vs. {self.restoration_image_stack.sizes['band']})"
-            )
-        for band_name in rt["band"].values:
-            try:
-                self.restoration_image_stack.sel(band=band_name)
-            except KeyError:
+        if rt != None: # allow None sets
+            if set(rt.dims) != {"band", "y", "x"} and set(rt.dims) != {"band"}:
                 raise ValueError(
-                    "recovery_target must contain the same band coordinates as composite_stack"
+                    "recovery_target must contain the dimension 'band' and optionally the dimensions 'y', and 'x'"
                 )
+            if rt.sizes["band"] != self.restoration_image_stack.sizes["band"]:
+                raise ValueError(
+                    f"recovery_target must contain the same number of bands as composite_stack ({rt.sizes['band']} vs. {self.restoration_image_stack.sizes['band']})"
+                )
+            for band_name in rt["band"].values:
+                try:
+                    self.restoration_image_stack.sel(band=band_name)
+                except KeyError:
+                    raise ValueError(
+                        "recovery_target must contain the same band coordinates as composite_stack"
+                    )
         self._recovery_target = rt
 
     @property


### PR DESCRIPTION
- [x] Allow setter to use None in RA
- [x] Allow None in compute_metrics
- [x] Add test that passing None works fine
- [x] Add test for err if metric that needs recovery_target is called but is None