### PR TITLE
ENH: Allow missing years in timeseries_data when appropriate 

### DIFF
--- a/src/spectral_recovery/metrics.py
+++ b/src/spectral_recovery/metrics.py
@@ -62,6 +62,12 @@ def compute_metrics(
 
     return metrics
 
+def has_no_missing_years(images: xr.DataArray):
+    """Check for continous set of years in DataArray"""
+    years = images.coords["time"].dt.year.values
+    if not np.all((years == list(range(years[0], years[-1] + 1)))):
+        return False
+    return True
 
 @register_metric
 def dnbr(ra: RestorationArea, params: Dict = {"timestep": 5}) -> xr.DataArray:
@@ -217,11 +223,15 @@ def y2r(ra: RestorationArea, params: Dict = {"percent_of_target": 80}) -> xr.Dat
     """
     if params["percent_of_target"] <= 0 or params["percent_of_target"] > 100:
         raise ValueError(VALID_PERC_MSP)
-    y2r_target = ra.recovery_target * (params["percent_of_target"] / 100)
+    
     recovery_window = ra.restoration_image_stack.sel(
         time=slice(ra.restoration_start, None)
     )
-
+    if not has_no_missing_years(recovery_window):
+        raise ValueError(f"Missing years. Y2R requires data for all years between {recovery_window.time.min()}-{recovery_window.time.max()}.")
+    
+    print(ra.recovery_target, params["percent_of_target"] )
+    y2r_target = ra.recovery_target * (params["percent_of_target"] / 100)
 
     years_to_recovery = (recovery_window >= y2r_target).argmax(dim="time", skipna=True)
     # Pixels with value 0 could be:

--- a/src/spectral_recovery/metrics.py
+++ b/src/spectral_recovery/metrics.py
@@ -22,7 +22,6 @@ def register_metric(f):
     METRIC_FUNCS[f.__name__] = f
     return f
 
-
 @maintain_rio_attrs
 def compute_metrics(
     timeseries_data: xr.DataArray,
@@ -222,6 +221,7 @@ def y2r(ra: RestorationArea, params: Dict = {"percent_of_target": 80}) -> xr.Dat
     recovery_window = ra.restoration_image_stack.sel(
         time=slice(ra.restoration_start, None)
     )
+
 
     years_to_recovery = (recovery_window >= y2r_target).argmax(dim="time", skipna=True)
     # Pixels with value 0 could be:

--- a/src/spectral_recovery/restoration.py
+++ b/src/spectral_recovery/restoration.py
@@ -146,11 +146,10 @@ class RestorationArea:
         """
         self._restoration_image_stack = None
 
-        if not t.satts.is_annual_composite:
+        if not t.satts.has_req_dims:
             raise ValueError(
-                "composite_stack is not a valid set of annual composites. Please"
-                " ensure there are no missing years and that the DataArray object"
-                " contains 'band', 'time', 'y' and 'x' dimensions."
+                "composite_stack missing required coordinate dimensions. Please"
+                " ensure the DataArray object contains 'band', 'time', 'y' and 'x' dimensions."
             ) from None
         self._full_timeseries = t
 

--- a/src/spectral_recovery/timeseries.py
+++ b/src/spectral_recovery/timeseries.py
@@ -57,32 +57,30 @@ class _SatelliteTimeSeries:
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
-        self._valid = None
-
-    # TODO: change this method to "is_continuous" or something and only check
-    # for continuity of years. Move the check for valid dim names to new method.
+    
     @property
-    def is_annual_composite(self) -> bool:
-        """Check if DataArray is contains valid annual composites.
+    def has_req_dims(self) -> bool:
+        """Check if DataArray has the required dims.
 
-        Checks whether the object has the required dimension labels (as
-        defined by/for project) and continuous years in the time dimension.
+        Checks if the object has the required band, time,
+        y, and x coordinate dimensions.
 
         Returns
         -------
         bool
             True if the DataArray is a valid annual composite, False otherwise.
         """
-        if self._valid is None:
-            years = self._obj.coords["time"].dt.year.values
-            # TODO: catch value error ("not broadcastable") here, indicates missing years
-            if not set(self._obj.dims) == set(REQ_DIMS):
-                self._valid = False
-            elif not np.all((years == list(range(min(years), max(years) + 1)))):
-                self._valid = False
-            else:
-                self._valid = True
-        return self._valid
+        if not set(self._obj.dims) == set(REQ_DIMS):
+            return False
+        return True
+    
+    @property
+    def has_no_year_breaks(self, start_year: int, end_year: int):
+        """Check all years between start_year-end_year exist"""
+        years = self._obj.coords["time"].dt.year.values
+        if not np.all((years == list(range(start_year, end_year + 1)))):
+            return False
+        return True
 
     def contains_spatial(self, polygons: gpd.GeoDataFrame) -> bool:
         """Check if DataArray spatially contains polygons.

--- a/src/tests/test_restoration.py
+++ b/src/tests/test_restoration.py
@@ -172,37 +172,6 @@ class TestRestorationAreaComposite:
                     recovery_target=recovery_target
                 )
 
-    def test_composite_stack_missing_years_throws_value_error(self):
-        with rioxarray.open_rasterio(TIMESERIES_LEN_3) as data:
-            # Set coordinates to 2020, 2021, and 2023, missing 2022
-            bad_stack = data
-            bad_stack = bad_stack.rename({"band": "time"})
-            bad_stack = bad_stack.expand_dims(dim={"band": [0]})
-            bad_stack = bad_stack.assign_coords(
-                time=([
-                    pd.to_datetime("2020"),
-                    pd.to_datetime("2021"),
-                    pd.to_datetime("2023"),
-                ])
-            )
-            recovery_target = xr.DataArray(np.ones(bad_stack.sizes["band"]), dims=["band"], coords={"band": [0]})
-
-
-            resto_poly = gpd.read_file(POLYGON_INBOUND)
-            resto_poly = set_dates(
-                resto_poly, dist="2020", rest="2021", ref_start="2019", ref_end="2019"
-            )
-
-            with pytest.raises(
-                ValueError,
-            ):
-                resto_a = RestorationArea(
-                    restoration_site=resto_poly,
-                    composite_stack=bad_stack,
-                    recovery_target=recovery_target
-                )
-
-
 class TestRestorationAreaPolygons:
     @pytest.fixture()
     def valid_timeseries(self):


### PR DESCRIPTION
Certain use-cases do not required a full annual timeseries of data to be passed to compute_metrics, e.g determining RRI, R80P, etc. Not requiring all years to be present will allow for faster processing in these scenarios. This PR:

- removes the requirements for all years to be present in the timeseries_data DataArray object
- adds checks to the Y2R metrics to ensure all years in the recovery window are present
- implements related tests