### PR TITLE
ENH: Silence expected RuntimeWarnings from Dask

### DIFF
--- a/src/spectral_recovery/metrics.py
+++ b/src/spectral_recovery/metrics.py
@@ -6,19 +6,48 @@ import xarray as xr
 import numpy as np
 import pandas as pd
 import geopandas as gpd
+import warnings 
+import functools
 
 from spectral_recovery.utils import maintain_rio_attrs
+
+warnings.filterwarnings("ignore", message="invalid value encountered in divide", category=RuntimeWarning)
+warnings.filterwarnings("ignore", message="All-NaN slice encountered", category=RuntimeWarning)
 
 NEG_TIMESTEP_MSG = "timestep cannot be negative."
 VALID_PERC_MSP = "percent must be between 0 and 100."
 METRIC_FUNCS = {}
-
 
 def register_metric(f):
     """Add function and name to global name/func dict"""
     METRIC_FUNCS[f.__name__] = f
     return f
 
+def silence_warnings(*warnings_specs: tuple) -> callable:
+    """Decorator to silence specific runtime warnings.
+
+    Used on recovery metric funcs where dividing by invalid 
+    values or all-Nan slices are expected.
+
+    Parameters
+    ----------
+    warning_specs : tuple 
+        Each tuple contains a (warning_type, message) pair to be silenced.
+
+    Returns
+    -------
+        function: The decorated function.
+    """
+    print("IN HERRRRREEE")
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with warnings.catch_warnings():
+                for warning_type, message in warnings_specs:
+                    
+                    return func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 @maintain_rio_attrs
 def compute_metrics(
@@ -113,7 +142,6 @@ def has_no_missing_years(images: xr.DataArray):
     if not np.all((years == list(range(years[0], years[-1] + 1)))):
         return False
     return True
-
 
 @register_metric
 def dir(
@@ -211,7 +239,6 @@ def yryr(
     obs_post_t = timeseries_data.sel(time=rest_post_t).drop_vars("time")
     obs_start = timeseries_data.sel(time=str(restoration_start)).drop_vars("time")
     yryr_v = ((obs_post_t - obs_start) / params["timestep"]).squeeze("time")
-
     return yryr_v
 
 
@@ -272,7 +299,6 @@ def r80p(
     except KeyError:
         pass
     return r80p_v
-
 
 @register_metric
 def y2r(

--- a/src/spectral_recovery/metrics.py
+++ b/src/spectral_recovery/metrics.py
@@ -6,8 +6,7 @@ import xarray as xr
 import numpy as np
 import pandas as pd
 import geopandas as gpd
-import warnings 
-import functools
+import warnings
 
 from spectral_recovery.utils import maintain_rio_attrs
 
@@ -22,32 +21,6 @@ def register_metric(f):
     """Add function and name to global name/func dict"""
     METRIC_FUNCS[f.__name__] = f
     return f
-
-def silence_warnings(*warnings_specs: tuple) -> callable:
-    """Decorator to silence specific runtime warnings.
-
-    Used on recovery metric funcs where dividing by invalid 
-    values or all-Nan slices are expected.
-
-    Parameters
-    ----------
-    warning_specs : tuple 
-        Each tuple contains a (warning_type, message) pair to be silenced.
-
-    Returns
-    -------
-        function: The decorated function.
-    """
-    print("IN HERRRRREEE")
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            with warnings.catch_warnings():
-                for warning_type, message in warnings_specs:
-                    
-                    return func(*args, **kwargs)
-        return wrapper
-    return decorator
 
 @maintain_rio_attrs
 def compute_metrics(


### PR DESCRIPTION
This PR silences the expected all-nan slice and invalid divide warnings issues by Dask. With many NaN values expected in a timeseries, and all-nan slices allowed, these warnings only serve to confuse the user.